### PR TITLE
feat: add error on empty uploadUrl and empty trackingId

### DIFF
--- a/bingads/bulk.go
+++ b/bingads/bulk.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -68,6 +69,10 @@ func (c *BulkService) GetBulkUploadUrl() (*GetBulkUploadUrlResponse, error) {
 	var getBulkUploadUrlResponse GetBulkUploadUrlResponse
 	if err = xml.Unmarshal(resp, &getBulkUploadUrlResponse); err != nil {
 		return nil, err
+	}
+
+	if getBulkUploadUrlResponse.RequestId == "" || getBulkUploadUrlResponse.UploadUrl == "" {
+		return nil, fmt.Errorf("unable to get bulk upload url, check your credentials")
 	}
 	return &getBulkUploadUrlResponse, nil
 }
@@ -148,5 +153,8 @@ func (c *BulkService) UploadBulkFile(url, filename string) (*UploadBulkFileRespo
 		return nil, err
 	}
 
+	if uploadBulkFileResponse.RequestId == "" || uploadBulkFileResponse.TrackingId == "" {
+		return nil, fmt.Errorf("unable to upload bulk file, check your credentials")
+	}
 	return &uploadBulkFileResponse, nil
 }


### PR DESCRIPTION
**Fixes** # (*issue*)
If the SDK cannot get the uploadURL while getting the upload URL or trackingID  while uploading a file, it will generate an error.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
